### PR TITLE
Add adaptive grid layouts to HomeView and StatsView

### DIFF
--- a/PrayerTracker/HomeView.swift
+++ b/PrayerTracker/HomeView.swift
@@ -88,6 +88,11 @@ struct HomeView: View {
         return Double(prayersMadeUpThisWeek) / Double(userProfile.weeklyGoal)
     }
 
+    /// Adaptive grid configuration for larger screens
+    private var gridColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 320), spacing: DesignSystem.Layout.gridSpacing)]
+    }
+
     
 
     private func updatePrayerStatus(prayerName: String, log: DailyLog, profile: UserProfile) {
@@ -228,7 +233,7 @@ struct HomeView: View {
     
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+            LazyVGrid(columns: gridColumns, alignment: .leading, spacing: DesignSystem.Layout.gridSpacing) {
                 // Header Section
                 HeaderView(
                     userName: userProfile.name,
@@ -252,7 +257,8 @@ struct HomeView: View {
                     onRetry: ensureTodaysLog
                 )
             }
-            .padding(.bottom, DesignSystem.Spacing.lg)
+            .adaptiveContentMargin()
+            .padding(.bottom, DesignSystem.Spacing.xl)
         }
         .navigationBarHidden(true)
         .onAppear {

--- a/PrayerTracker/StatsView.swift
+++ b/PrayerTracker/StatsView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import SwiftData
-import Charts
 
 struct StatsView: View {
     @Environment(StatsService.self) private var statsService
@@ -29,7 +28,7 @@ struct StatsView: View {
                         GridRow {
                             VStack {
                                 ProgressView("Loading statistics...")
-                                    .padding()
+                                    .adaptivePadding()
                             }
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                             .gridCellColumns(horizontalSizeClass == .regular ? 2 : 1)

--- a/PrayerTracker/StatsView.swift
+++ b/PrayerTracker/StatsView.swift
@@ -4,13 +4,13 @@ import Charts
 
 struct StatsView: View {
     @Environment(StatsService.self) private var statsService
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Query private var userProfiles: [UserProfile]
-    
+
     let userID: String
-    
+
     init(userID: String) {
         self.userID = userID
-        
         // Filter UserProfile by userID for data isolation
         self._userProfiles = Query(
             filter: #Predicate<UserProfile> { profile in
@@ -22,133 +22,145 @@ struct StatsView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                if statsService.isLoading {
-                    VStack {
-                        ProgressView("Loading statistics...")
-                            .padding()
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if statsService.hasError {
-                    VStack {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.largeTitle)
-                            .foregroundColor(.orange)
-                        Text("Unable to load statistics")
-                            .font(.headline)
-                        Text("Please try again")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Button("Retry") {
-                            statsService.fetchData()
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .padding(.top)
-                    }
-                    .padding()
-                } else if let profile = userProfiles.first {
-                    VStack(spacing: 15) {
-                        // Overall Completion Card
-                        VStack {
-                            Text("Overall Completion")
-                                .font(.headline)
-                            Gauge(value: statsService.overallCompletionPercentage) {
-                                Text("\(Int(statsService.overallCompletionPercentage * 100))%")
+                Grid(alignment: .topLeading,
+                     horizontalSpacing: DesignSystem.Layout.gridSpacing,
+                     verticalSpacing: DesignSystem.Layout.gridSpacing) {
+                    if statsService.isLoading {
+                        GridRow {
+                            VStack {
+                                ProgressView("Loading statistics...")
+                                    .padding()
                             }
-                            .gaugeStyle(.accessoryCircularCapacity)
-                            .tint(.accentColor)
-                            .frame(width: 100, height: 100)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .gridCellColumns(horizontalSizeClass == .regular ? 2 : 1)
                         }
+                    } else if statsService.hasError {
+                        GridRow {
+                            VStack {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .font(.largeTitle)
+                                    .foregroundColor(.orange)
+                                Text("Unable to load statistics")
+                                    .font(.headline)
+                                Text("Please try again")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Button("Retry") {
+                                    statsService.fetchData()
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .padding(.top)
+                            }
+                            .adaptivePadding()
+                            .gridCellColumns(horizontalSizeClass == .regular ? 2 : 1)
+                        }
+                    } else if let profile = userProfiles.first {
+                        GridRow {
+                            VStack {
+                                Text("Overall Completion")
+                                    .font(.headline)
+                                Gauge(value: statsService.overallCompletionPercentage) {
+                                    Text("\(Int(statsService.overallCompletionPercentage * 100))%")
+                                }
+                                .gaugeStyle(.accessoryCircularCapacity)
+                                .tint(.accentColor)
+                                .frame(width: 100, height: 100)
+                            }
 
-
-
-                        // Prayer-Type Breakdown
-                        VStack(alignment: .leading) {
-                            Text("Prayer Breakdown")
-                                .font(.headline)
-                                .padding(.bottom, 5)
-                            ForEach(statsService.prayerBreakdown, id: \.0.rawValue) { (prayerType, percentage, madeUp, initialOwed) in
-                                VStack(alignment: .leading) {
-                                    HStack {
-                                        Text(prayerType.rawValue)
-                                            .frame(width: 80, alignment: .leading)
-                                        ProgressView(value: percentage)
-                                            .tint(prayerType.color)
-                                            .frame(height: 6)
-                                        Text("\(madeUp)/\(initialOwed)")
-                                            .frame(width: 60, alignment: .trailing)
+                            VStack(alignment: .leading) {
+                                Text("Prayer Breakdown")
+                                    .font(.headline)
+                                    .padding(.bottom, 5)
+                                ForEach(statsService.prayerBreakdown, id: \.0.rawValue) { (prayerType, percentage, madeUp, initialOwed) in
+                                    VStack(alignment: .leading) {
+                                        HStack {
+                                            Text(prayerType.rawValue)
+                                                .frame(width: 80, alignment: .leading)
+                                            ProgressView(value: percentage)
+                                                .tint(prayerType.color)
+                                                .frame(height: 6)
+                                            Text("\(madeUp)/\(initialOwed)")
+                                                .frame(width: 60, alignment: .trailing)
+                                        }
                                     }
                                 }
                             }
                         }
 
-                        // Key Metrics & Streaks
-                        VStack(alignment: .leading) {
-                            Text("Key Metrics")
-                                .font(.headline)
-                                .padding(.bottom, 5)
-                            HStack {
-                                Text("Current Streak:")
-                                Spacer()
-                                Text("\(statsService.currentStreak) days")
-                            }
-                            HStack {
-                                Text("Longest Streak:")
-                                Spacer()
-                                Text("\(statsService.longestStreak) days")
-                            }
-                            HStack {
-                                Text("Best Day:")
-                                Spacer()
-                                Text("(\(statsService.bestDay?.prayersCompleted ?? 0) prayers)")
-                            }
-                        }
-
-                        // Pace & Finish Forecast
-                        VStack(alignment: .leading) {
-                            Text("Pace & Forecast")
-                                .font(.headline)
-                                .padding(.bottom, 5)
-                            HStack {
-                                Text("Estimated Completion:")
-                                Spacer()
-                                Text(statsService.forecastDate)
-                            }
-                        }
-
-                        // Weekly Goal Bar
-                        VStack(alignment: .leading) {
-                            Text("Weekly Goal")
-                                .font(.headline)
-                                .padding(.bottom, 5)
-                            ProgressView(value: Double(statsService.weeklyBundles.completed), total: Double(statsService.weeklyBundles.goal)) {
-                                Text("(\(statsService.weeklyBundles.completed) / \(statsService.weeklyBundles.goal) bundles)")
-                            }
-                            .tint(.orange)
-                            .frame(height: 6)
-                        }
-
-                        // History Deep-Link
-                        NavigationLink(destination: HistoryView(userID: userID)) {
-                            HStack {
-                                Image(systemName: "clock.arrow.circlepath")
-                                Text("View Full History")
+                        GridRow {
+                            VStack(alignment: .leading) {
+                                Text("Key Metrics")
                                     .font(.headline)
-                                Spacer()
-                                Image(systemName: "chevron.right")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
+                                    .padding(.bottom, 5)
+                                HStack {
+                                    Text("Current Streak:")
+                                    Spacer()
+                                    Text("\(statsService.currentStreak) days")
+                                }
+                                HStack {
+                                    Text("Longest Streak:")
+                                    Spacer()
+                                    Text("\(statsService.longestStreak) days")
+                                }
+                                HStack {
+                                    Text("Best Day:")
+                                    Spacer()
+                                    Text("(\(statsService.bestDay?.prayersCompleted ?? 0) prayers)")
+                                }
                             }
-                            .padding()
-                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+
+                            VStack(alignment: .leading) {
+                                Text("Pace & Forecast")
+                                    .font(.headline)
+                                    .padding(.bottom, 5)
+                                HStack {
+                                    Text("Estimated Completion:")
+                                    Spacer()
+                                    Text(statsService.forecastDate)
+                                }
+                            }
                         }
-                        .buttonStyle(PlainButtonStyle())
+
+                        GridRow {
+                            VStack(alignment: .leading) {
+                                Text("Weekly Goal")
+                                    .font(.headline)
+                                    .padding(.bottom, 5)
+                                ProgressView(value: Double(statsService.weeklyBundles.completed), total: Double(statsService.weeklyBundles.goal)) {
+                                    Text("(\(statsService.weeklyBundles.completed) / \(statsService.weeklyBundles.goal) bundles)")
+                                }
+                                .tint(.orange)
+                                .frame(height: 6)
+                            }
+                            .gridCellColumns(horizontalSizeClass == .regular ? 2 : 1)
+                        }
+
+                        GridRow {
+                            NavigationLink(destination: HistoryView(userID: userID)) {
+                                HStack {
+                                    Image(systemName: "clock.arrow.circlepath")
+                                    Text("View Full History")
+                                        .font(.headline)
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                .adaptivePadding()
+                                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                            .gridCellColumns(horizontalSizeClass == .regular ? 2 : 1)
+                        }
+                    } else {
+                        GridRow {
+                            Text("No user profile found. Please complete the onboarding.")
+                                .gridCellColumns(horizontalSizeClass == .regular ? 2 : 1)
+                        }
                     }
-                    .padding()
-                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
-                    .padding()
-                } else {
-                    Text("No user profile found. Please complete the onboarding.")
                 }
+                .adaptiveContentMargin()
+                .padding(.bottom, DesignSystem.Spacing.xl)
             }
             .navigationTitle("Statistics")
             .refreshable {
@@ -166,3 +178,4 @@ struct StatsView: View {
         .modelContainer(for: [UserProfile.self, PrayerDebt.self, DailyLog.self])
         .environment(StatsService(modelContext: ModelContext(try! ModelContainer(for: UserProfile.self, PrayerDebt.self, DailyLog.self)), userID: "preview-user"))
 }
+


### PR DESCRIPTION
## Summary
- refactor HomeView to use `LazyVGrid` with adaptive column sizing
- refactor StatsView to use the new `Grid` API for multi‑column layouts
- use `DesignSystem` utilities for consistent padding

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_687d5e219194832080bfd18854ce3dc3