### PR TITLE
Add animations for prayer updates and stats loading

### DIFF
--- a/PrayerTracker/PrayerCardView.swift
+++ b/PrayerTracker/PrayerCardView.swift
@@ -18,10 +18,12 @@ struct PrayerCardView: View {
             Text("Today: \(prayersCompletedToday)")
                 .font(.callout)
                 .foregroundColor(.secondary)
+                .animation(.spring(), value: prayersCompletedToday)
 
             Text("\(prayerOwed) Remaining")
                 .font(.callout)
                 .foregroundColor(.secondary)
+                .animation(.spring(), value: prayerOwed)
 
             Button(action: { 
                 onLog(prayerName)

--- a/PrayerTracker/StatsView.swift
+++ b/PrayerTracker/StatsView.swift
@@ -28,6 +28,7 @@ struct StatsView: View {
                             .padding()
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .transition(.opacity)
                 } else if statsService.hasError {
                     VStack {
                         Image(systemName: "exclamationmark.triangle")
@@ -45,6 +46,7 @@ struct StatsView: View {
                         .padding(.top)
                     }
                     .padding()
+                    .transition(.opacity)
                 } else if let profile = userProfiles.first {
                     VStack(spacing: 15) {
                         // Overall Completion Card
@@ -157,6 +159,7 @@ struct StatsView: View {
             .onAppear {
                 statsService.fetchData()
             }
+            .animation(.easeOut(duration: 0.3), value: statsService.isLoading)
         }
     }
 }


### PR DESCRIPTION
## Summary
- animate changes in `PrayerCardView` when prayers are logged or debt decreases
- fade `StatsView` loading and error states with transitions
- add ease-out animation when stats start/finish loading

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687d64bd87b88320bacc78f4c752b7c7