### PR TITLE
Fix fonts and add accessibility labels

### DIFF
--- a/PrayerTracker/SignInView.swift
+++ b/PrayerTracker/SignInView.swift
@@ -26,6 +26,7 @@ struct SignInView: View {
                     .ignoresSafeArea(.all, edges: .top)
                     .opacity(illustrationOpacity)
                     .animation(.easeIn(duration: 0.35), value: illustrationOpacity)
+                    .accessibilityHidden(true)
                 
                 // Content Section - Positioned below hero image
                 VStack(spacing: 0) {
@@ -39,15 +40,15 @@ struct SignInView: View {
                     // Headline Block
                     VStack(spacing: 4) {
                         Text("Welcome to")
-                            .font(.system(size: 34, weight: .bold, design: .default))
+                            .font(DesignSystem.Typography.title1())
                             .foregroundColor(.primary)
                         
                         Text("your personal")
-                            .font(.system(size: 34, weight: .bold, design: .default))
+                            .font(DesignSystem.Typography.title1())
                             .foregroundColor(.primary)
                         
                         Text("Prayer Tracker")
-                            .font(.system(size: 34, weight: .bold, design: .default))
+                            .font(DesignSystem.Typography.title1())
                             .foregroundColor(.primary)
                     }
                     .multilineTextAlignment(.center)
@@ -73,6 +74,8 @@ struct SignInView: View {
                             RoundedRectangle(cornerRadius: 16, style: .continuous)
                                 .stroke(Color.primary.opacity(0.1), lineWidth: 1)
                         )
+                        .accessibilityLabel("Sign in with Apple")
+                        .accessibilityHint("Use your Apple ID to sign in")
                         
                         // Continue with Google - Secondary
                         Button(action: {
@@ -83,9 +86,10 @@ struct SignInView: View {
                                     .resizable()
                                     .frame(width: 20, height: 20)
                                     .foregroundColor(.red)
+                                    .accessibilityHidden(true)
                                 
                                 Text("Continue with Google")
-                                    .font(.system(size: 17, weight: .medium))
+                                    .font(DesignSystem.Typography.body()).fontWeight(.medium)
                                     .foregroundColor(.primary)
                             }
                             .frame(maxWidth: .infinity)
@@ -96,6 +100,8 @@ struct SignInView: View {
                                     .stroke(Color.primary.opacity(0.1), lineWidth: 1)
                             )
                         }
+                        .accessibilityLabel("Continue with Google")
+                        .accessibilityHint("Sign in with your Google account")
                         .scaleEffect(1.0)
                         .animation(.easeInOut(duration: 0.1), value: false)
                     }
@@ -116,6 +122,7 @@ struct SignInView: View {
                             .font(.caption)
                             .foregroundColor(.accentColor)
                             .underline()
+                            .accessibilityHint("View the terms of service")
                             
                             Text("and")
                                 .font(.caption)
@@ -127,6 +134,7 @@ struct SignInView: View {
                             .font(.caption)
                             .foregroundColor(.accentColor)
                             .underline()
+                            .accessibilityHint("Read the privacy policy")
                         }
                     }
                     .multilineTextAlignment(.center)

--- a/PrayerTracker/Views/HomeView/TodaysLogView.swift
+++ b/PrayerTracker/Views/HomeView/TodaysLogView.swift
@@ -78,8 +78,9 @@ private struct ErrorStateView: View {
     var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 32))
+                .font(.largeTitle)
                 .foregroundColor(.orange)
+                .accessibilityHidden(true)
             
             Text("Failed to Load Today's Log")
                 .font(.headline)
@@ -107,8 +108,9 @@ private struct EmptyStateView: View {
     var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "calendar.badge.plus")
-                .font(.system(size: 32))
+                .font(.largeTitle)
                 .foregroundColor(.blue)
+                .accessibilityHidden(true)
             
             Text("No Log Found")
                 .font(.headline)

--- a/PrayerTracker/Views/Onboarding/DebtCalculationView.swift
+++ b/PrayerTracker/Views/Onboarding/DebtCalculationView.swift
@@ -25,7 +25,7 @@ struct DebtCalculationView: View {
     var body: some View {
         VStack(spacing: 30) {
             Text("Calculate Your Prayer Debt")
-                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .font(DesignSystem.Typography.title1())
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 

--- a/PrayerTracker/Views/Onboarding/GoalSelectionView.swift
+++ b/PrayerTracker/Views/Onboarding/GoalSelectionView.swift
@@ -7,12 +7,12 @@ struct GoalSelectionView: View {
     var body: some View {
         VStack(spacing: 30) {
             Text("Set Your Daily Goal")
-                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .font(DesignSystem.Typography.title1())
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
             Text("How many Qada prayers do you aim to complete each day?")
-                .font(.system(size: 18, weight: .regular, design: .rounded))
+                .font(DesignSystem.Typography.body())
                 .multilineTextAlignment(.center)
                 .foregroundColor(.secondary)
                 .padding(.horizontal)

--- a/PrayerTracker/Views/Onboarding/OnboardingSummaryView.swift
+++ b/PrayerTracker/Views/Onboarding/OnboardingSummaryView.swift
@@ -58,7 +58,7 @@ struct OnboardingSummaryView: View {
     var body: some View {
         VStack(spacing: 30) {
             Text("Ready to Start?")
-                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .font(DesignSystem.Typography.title1())
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
@@ -77,7 +77,7 @@ struct OnboardingSummaryView: View {
     private var summaryCard: some View {
         VStack(alignment: .leading, spacing: 15) {
             Text("Summary")
-                .font(.system(size: 22, weight: .bold, design: .rounded))
+                .font(DesignSystem.Typography.title3()).fontWeight(.bold)
             summaryRow(label: "Name", value: name)
             summaryRow(label: "Gender", value: gender)
             summaryRow(label: "Calculation Method", value: calculationMethod.rawValue)
@@ -91,7 +91,7 @@ struct OnboardingSummaryView: View {
     private var goalCard: some View {
         VStack(alignment: .leading, spacing: 15) {
             Text("Your Goal")
-                .font(.system(size: 22, weight: .bold, design: .rounded))
+                .font(DesignSystem.Typography.title3()).fontWeight(.bold)
             summaryRow(label: "Daily Goal", value: "\(dailyGoal) prayers")
             summaryRow(label: "Weekly Goal", value: "\(dailyGoal * 7) prayers")
             summaryRow(label: "Estimated Completion", value: estimatedCompletionDate)
@@ -104,11 +104,11 @@ struct OnboardingSummaryView: View {
     private func summaryRow(label: String, value: String) -> some View {
         HStack {
             Text(label)
-                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                .font(DesignSystem.Typography.headline())
                 .foregroundColor(.secondary)
             Spacer()
             Text(value)
-                .font(.system(size: 16, weight: .medium, design: .rounded))
+                .font(DesignSystem.Typography.body()).fontWeight(.medium)
         }
     }
 }

--- a/PrayerTracker/Views/Onboarding/UserInfoView.swift
+++ b/PrayerTracker/Views/Onboarding/UserInfoView.swift
@@ -16,23 +16,23 @@ struct UserInfoView: View {
     var body: some View {
         VStack(spacing: 30) {
             Text("Tell Us About Yourself")
-                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .font(DesignSystem.Typography.title1())
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
             VStack(alignment: .leading, spacing: 20) {
                 Text("What should we call you?")
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .font(DesignSystem.Typography.headline())
                     .foregroundColor(.secondary)
 
                 TextField("Your Name", text: $name)
                     .padding()
                     .background(Color(UIColor.secondarySystemBackground))
                     .cornerRadius(16)
-                    .font(.system(size: 18, weight: .regular, design: .rounded))
+                    .font(DesignSystem.Typography.body())
 
                 Text("Please select your gender.")
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .font(DesignSystem.Typography.headline())
                     .foregroundColor(.secondary)
 
                 Picker("Gender", selection: $gender) {

--- a/PrayerTracker/Views/Onboarding/WelcomeView.swift
+++ b/PrayerTracker/Views/Onboarding/WelcomeView.swift
@@ -23,6 +23,7 @@ struct WelcomeView: View {
                     .ignoresSafeArea(.all, edges: .top)
                     .opacity(illustrationOpacity)
                     .animation(.easeIn(duration: 0.35), value: illustrationOpacity)
+                    .accessibilityHidden(true)
                 
                 // Content Section - Scrollable content below hero image
                 VStack(spacing: 0) {
@@ -39,11 +40,11 @@ struct WelcomeView: View {
                             // Headline
                             VStack(spacing: 2) {
                                 Text("Welcome to")
-                                    .font(.system(size: 28, weight: .bold, design: .default))
+                                    .font(DesignSystem.Typography.title2())
                                     .foregroundColor(.primary)
                                 
                                 Text("PrayerTracker")
-                                    .font(.system(size: 28, weight: .bold, design: .default))
+                                    .font(DesignSystem.Typography.title2())
                                     .foregroundColor(.primary)
                             }
                             .multilineTextAlignment(.center)
@@ -53,13 +54,13 @@ struct WelcomeView: View {
                             // Problem Block
                             VStack(spacing: 12) {
                                 Text("Problem")
-                                    .font(.system(size: 16, weight: .semibold, design: .default))
+                                    .font(DesignSystem.Typography.headline())
                                     .foregroundColor(.secondary)
                                     .textCase(.uppercase)
                                     .tracking(0.5)
                                 
                                 Text("Keeping track of missed prayers is hard: notebooks get lost, mental counts drift, and motivation fades.")
-                                    .font(.system(size: 16, weight: .medium, design: .default))
+                                    .font(DesignSystem.Typography.body()).fontWeight(.medium)
                                     .foregroundColor(.primary)
                                     .multilineTextAlignment(.center)
                                     .lineLimit(nil)
@@ -70,7 +71,7 @@ struct WelcomeView: View {
                             // Why PrayerTracker? Block
                             VStack(spacing: 12) {
                                 Text("Why PrayerTracker?")
-                                    .font(.system(size: 16, weight: .semibold, design: .default))
+                                    .font(DesignSystem.Typography.headline())
                                     .foregroundColor(.secondary)
                                     .textCase(.uppercase)
                                     .tracking(0.5)
@@ -80,9 +81,10 @@ struct WelcomeView: View {
                                     HStack(spacing: 8) {
                                         Image(systemName: "checkmark.circle.fill")
                                             .foregroundColor(.accentColor)
-                                            .font(.system(size: 14, weight: .medium))
+                                            .font(DesignSystem.Typography.caption()).fontWeight(.medium)
+                                            .accessibilityHidden(true)
                                         Text("Accurate totals")
-                                            .font(.system(size: 15, weight: .medium, design: .default))
+                                            .font(DesignSystem.Typography.body()).fontWeight(.medium)
                                             .foregroundColor(.primary)
                                         Spacer()
                                     }
@@ -90,9 +92,10 @@ struct WelcomeView: View {
                                     HStack(spacing: 8) {
                                         Image(systemName: "checkmark.circle.fill")
                                             .foregroundColor(.accentColor)
-                                            .font(.system(size: 14, weight: .medium))
+                                            .font(DesignSystem.Typography.caption()).fontWeight(.medium)
+                                            .accessibilityHidden(true)
                                         Text("Guided daily goals")
-                                            .font(.system(size: 15, weight: .medium, design: .default))
+                                            .font(DesignSystem.Typography.body()).fontWeight(.medium)
                                             .foregroundColor(.primary)
                                         Spacer()
                                     }
@@ -100,9 +103,10 @@ struct WelcomeView: View {
                                     HStack(spacing: 8) {
                                         Image(systemName: "checkmark.circle.fill")
                                             .foregroundColor(.accentColor)
-                                            .font(.system(size: 14, weight: .medium))
+                                            .font(DesignSystem.Typography.caption()).fontWeight(.medium)
+                                            .accessibilityHidden(true)
                                         Text("Sync & privacy")
-                                            .font(.system(size: 15, weight: .medium, design: .default))
+                                            .font(DesignSystem.Typography.body()).fontWeight(.medium)
                                             .foregroundColor(.primary)
                                         Spacer()
                                     }
@@ -113,7 +117,7 @@ struct WelcomeView: View {
                             
                             // Payoff Line
                             Text("Turn backlog into clear, achievable milestones.")
-                                .font(.system(size: 16, weight: .medium, design: .default))
+                                .font(DesignSystem.Typography.body()).fontWeight(.medium)
                                 .foregroundColor(.accentColor)
                                 .multilineTextAlignment(.center)
                                 .lineLimit(nil)
@@ -127,7 +131,7 @@ struct WelcomeView: View {
                                 }
                             }) {
                                 Text("Get Started")
-                                    .font(.system(size: 17, weight: .semibold))
+                                    .font(DesignSystem.Typography.body()).fontWeight(.semibold)
                                     .foregroundColor(.white)
                                     .frame(maxWidth: .infinity)
                                     .frame(height: 50)
@@ -137,6 +141,8 @@ struct WelcomeView: View {
                                             .stroke(Color.primary.opacity(0.1), lineWidth: 1)
                                     )
                             }
+                            .accessibilityLabel("Get Started")
+                            .accessibilityHint("Begin setting up PrayerTracker")
                             .padding(.horizontal, 24)
                             .padding(.bottom, max(32, geometry.safeAreaInsets.bottom + 16))
                         }


### PR DESCRIPTION
## Summary
- replace `.font(.system)` hard-coded fonts with scalable DesignSystem variants
- hide decorative images from accessibility and add missing labels or hints

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d64aba9ec8320beb31da235d9900d